### PR TITLE
Allow to use the middleware class name instead

### DIFF
--- a/src/Wrapper.php
+++ b/src/Wrapper.php
@@ -19,10 +19,10 @@ class Wrapper
     /**
      * Wrap and register the middleware in the Container
      *
-     * @param  $abstract
-     * @param  Closure $callable
+     * @param  string         $abstract
+     * @param  Closure|string $callable
      */
-    public function bind($abstract, Closure $callable)
+    public function bind($abstract, $callable)
     {
         $this->container->bind($abstract, function() use($callable) {
             return $this->wrap($callable);
@@ -32,13 +32,18 @@ class Wrapper
     /**
      * Wrap the StackPHP Middleware in a Laravel Middleware
      *
-     * @param  Closure $callable
+     * @param  Closure|string  $callable
      * @return ClosureMiddleware
      */
-    public function wrap(Closure $callable)
+    public function wrap($callable)
     {
         $kernel = new ClosureHttpKernel();
-        $middleware = $callable($kernel);
+
+        if (is_callable($callable)) {
+            $middleware = $callable($kernel);
+        } else {
+            $middleware = new $callable($kernel)
+        }
 
         return new ClosureMiddleware($kernel, $middleware);
     }


### PR DESCRIPTION
These would all be the same:

``` php
$stack = app('stack');

$middleware = $stack->wrap(League\StackRobots\Robots::class);
app()->instance('League\StackRobots\RobotsMiddleware', $middleware);
```

or

``` php
app('stack')->bind('League\StackRobots\RobotsMiddleware', League\StackRobots\Robots::class);
```

or

``` php
app('stack')->bind('League\StackRobots\RobotsMiddleware', function ($kernel) {
    return new \League\StackRobots\Robots($kernel);
});
```
