### PR TITLE
Fix Laravel 5.4 support

### DIFF
--- a/src/StackMiddleware.php
+++ b/src/StackMiddleware.php
@@ -1,5 +1,6 @@
 <?php namespace Barryvdh\StackMiddleware;
 
+use ReflectionClass;
 use Illuminate\Contracts\Container\Container;
 use Symfony\Component\HttpKernel\TerminableInterface;
 
@@ -47,7 +48,8 @@ class StackMiddleware
         } else {
             // Add kernel as first parameter
             array_unshift($params, $kernel);
-            $middleware = $this->container->make($callable, $params);
+            $reflect  = new ReflectionClass($callable);
+            $middleware = $reflect->newInstanceArgs($params);
         }
 
         if ($middleware instanceof TerminableInterface) {

--- a/src/StackMiddleware.php
+++ b/src/StackMiddleware.php
@@ -1,6 +1,5 @@
 <?php namespace Barryvdh\StackMiddleware;
 
-use ReflectionClass;
 use Illuminate\Contracts\Container\Container;
 use Symfony\Component\HttpKernel\TerminableInterface;
 
@@ -48,8 +47,8 @@ class StackMiddleware
         } else {
             // Add kernel as first parameter
             array_unshift($params, $kernel);
-            $reflect  = new ReflectionClass($callable);
-            $middleware = $reflect->newInstanceArgs($params);
+            $makeMethod = method_exists($this->container, 'makeWith') ?  'makeWith' : 'make';
+            $middleware = $this->container->$makeMethod($callable, $params);
         }
 
         if ($middleware instanceof TerminableInterface) {

--- a/src/StackMiddleware.php
+++ b/src/StackMiddleware.php
@@ -45,8 +45,8 @@ class StackMiddleware
         if (is_callable($callable)) {
             $middleware = $callable($kernel);
         } else {
-            // Add kernel as first parameter
-            array_unshift($params, $kernel);
+            // Add kernel as 'app' parameter
+            $params = ['app' => $kernel] + $params;
             $makeMethod = method_exists($this->container, 'makeWith') ?  'makeWith' : 'make';
             $middleware = $this->container->$makeMethod($callable, $params);
         }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -23,7 +23,7 @@ class ServiceProviderTest extends PHPUnit_Framework_TestCase
     {
         $this->app = $this->getMockBuilder('Illuminate\Contracts\Container\Container')
             ->setMethods([
-                'bind', 'alias', 'tagged', 'tag', 'bindIf', 'bound', 'singleton', 'extend',
+                'bind', 'alias', 'factory', 'tagged', 'tag', 'bindIf', 'bound', 'singleton', 'extend',
                 'instance', 'when', 'make', 'call', 'resolved', 'resolving', 'afterResolving',
             ])->getMock();
         $this->serviceProvider = new ServiceProvider($this->app);

--- a/tests/StackMiddlewareTest.php
+++ b/tests/StackMiddlewareTest.php
@@ -22,7 +22,11 @@ class StackMiddlewareTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->container = $this->getMock('Illuminate\Contracts\Container\Container');
+        $this->container = $this->getMockBuilder('Illuminate\Contracts\Container\Container')
+            ->setMethods([
+                'bind', 'alias', 'factory', 'tagged', 'tag', 'bindIf', 'bound', 'singleton', 'extend',
+                'instance', 'when', 'make', 'makeWith', 'call', 'resolved', 'resolving', 'afterResolving',
+            ])->getMock();
         $this->stackMiddleware = new StackMiddleware($this->container);
     }
 
@@ -34,13 +38,13 @@ class StackMiddlewareTest extends PHPUnit_Framework_TestCase
         $arg2 = 'arg2';
 
         $this->container->expects($this->once())
-            ->method('make')
+            ->method('makeWith')
             ->with(
                 $this->equalTo($middlewareName),
-                $this->equalTo([new ClosureHttpKernel(), $arg1, $arg2])
+                $this->equalTo(['app' => new ClosureHttpKernel(), 'env' => $arg1, 'envVar' => $arg2])
             )->will($this->returnValue($kernelStub));
 
-        $result = $this->stackMiddleware->wrap($middlewareName, [$arg1, $arg2]);
+        $result = $this->stackMiddleware->wrap($middlewareName, ['env' => $arg1, 'envVar' => $arg2]);
 
         $this->assertNotInstanceOf('Barryvdh\StackMiddleware\TerminableClosureMiddleware', $result);
         $this->assertInstanceOf('Barryvdh\StackMiddleware\ClosureMiddleware', $result);


### PR DESCRIPTION
Fix the `BindingResolutionException`:
```
 in Container.php line 804: Target [Symfony\Component\HttpKernel\HttpKernelInterface] is not instantiable
```

Because, since Laravel 5.4:
> the container's make method no longer accepts a second array of parameters.

We also can use this line of code, but it's only compatible with PHP >= 5.6.0:
```php
$middleware = new $callable(...$params);
```
Source: http://stackoverflow.com/a/2409288