### PR TITLE
fix: undefined constant MASTER_REQUEST

### DIFF
--- a/src/ClosureHttpKernel.php
+++ b/src/ClosureHttpKernel.php
@@ -24,7 +24,7 @@ class ClosureHttpKernel implements HttpKernelInterface
      *
      * @return Response A Response instance
      */
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
+    public function handle(Request $request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
     {
         $closure = $this->closure;
 


### PR DESCRIPTION
Symfony removed the deprecated `MASTER_REQUEST` in version 7.0:
https://github.com/symfony/http-kernel/commit/08c086685907353c42bd79cd205d717abd3b2189#diff-80ada072273fdb4f8d05f777563b32ac1f789cf168f834c0518f02d4a63e43e7L31